### PR TITLE
fix: use reportTypeId for equality check and some null checks

### DIFF
--- a/tap_youtube_analytics/sync.py
+++ b/tap_youtube_analytics/sync.py
@@ -223,6 +223,8 @@ def sync_playlist_items(client,
                 time_extracted = utils.now()
 
                 for record in records:
+                    if record is None:
+                        continue
                     for key in id_fields:
                         if not record.get(key):
                             raise ValueError('Stream: {}, Missing key: {}'.format(stream_name, key))
@@ -303,6 +305,8 @@ def sync_videos(client,
 
             i = 0
             for search_record in search_records:
+                if search_record is None:
+                    continue
                 video_id = search_record.get('id', {}).get('videoId')
                 video_ids.append(video_id)
 
@@ -406,8 +410,8 @@ def sync_report(client,
         # Check if job exists for stream
         job_exists = False
         for job in jobs:
-            job_name = job.get('name')
-            if job_name == stream_name:
+            job_report_id = job.get('reportTypeId')
+            if job_report_id == report_type:
                 job_exists = True
                 job_id = job.get('id')
                 break


### PR DESCRIPTION
# Description of change
When checking for existing youtube reporting jobs, the tap uses the `job.name` to check if it exists in the stream but `job.name` is user specified and could be different from what's expected. Specifically in cases where the job wasn't created by the tap. The fix is to use the `job.reportTypeId` which is consistent across, ensuring we don't try to create an existing job which throws a 409 error and breaks the tap.

Other changes are just some null checks that break the tap.